### PR TITLE
Add argparse command-line argument parser

### DIFF
--- a/folderizer/__init__.py
+++ b/folderizer/__init__.py
@@ -1,2 +1,11 @@
+import argparse
+
+parser = argparse.ArgumentParser(
+    prog="folderizer",
+    description="File organization command-line tool.",
+    epilog="Thanks for using %(prog)s!")
+parser.add_argument('filepath')
+args = parser.parse_args()
+
 def example_function():
     return 1 + 1

--- a/folderizer/__init__.py
+++ b/folderizer/__init__.py
@@ -5,6 +5,7 @@ parser = argparse.ArgumentParser(
     description="File organization command-line tool.",
     epilog="Thanks for using %(prog)s!")
 parser.add_argument('filepath')
+parser.add_argument("-v","--version", action="version", version="%(prog)s 0.1.0")
 args = parser.parse_args()
 
 def example_function():


### PR DESCRIPTION
This resolves #1 


Adds command-line argument parsing using [argparse](https://docs.python.org/3/library/argparse.html).
This PR adds support for the following flags:
- Help (-h, --help)
- Version (-v, --version)