### PR TITLE
Add Linting and Static Type Checking using ruff and mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,3 +26,7 @@ CI = "https://github.com/rjwignar/folderizer/actions"
 
 [project.optional-dependencies]
 test = ["pytest"]
+dev = [
+  "ruff",
+  "mypy"
+]


### PR DESCRIPTION
This fixes #4.
Summary
---
Adds the following `dev` optional dependencies:
- [ruff](https://docs.astral.sh/ruff/) (Python linter)
- [mypy](https://mypy.readthedocs.io/en/stable/) (Python static type checker)

During development, these can be installed with [pip](https://pip.pypa.io/en/stable/) (from inside the repo root directory):
```pip install .[dev]```