### PR TITLE
Add linting workflow

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,18 @@
+# .github/workflows/ruff.yml
+
+name: Ruff
+
+on:
+    pull_request:
+      branches:
+        - main
+    push:
+      branches:
+        - main
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: chartboost/ruff-action@v1


### PR DESCRIPTION
This fixes #6

This adds `ruff.yml` as described in the [ruff documentation](https://docs.astral.sh/ruff/integrations/#github-actions).
This workflow uses [ChartBoost/ruff-action](https://github.com/chartboost/ruff-action) as a pass-fail test for linter violations