### PR TITLE
Draft folderizer default routine

### DIFF
--- a/folderizer/__init__.py
+++ b/folderizer/__init__.py
@@ -1,4 +1,15 @@
 import argparse
+import os
+
+images = [".jpeg", ".jpg", ".png", ".gif"]
+videos = [".mp4", ".flv", ".m4v", ".webm"]
+text = [ ".txt", ".md", ".doc", ".docx", ".pdf"]
+imageCount = 0
+movedImagesCount = 0
+videoCount = 0
+movedVideosCount = 0
+textCount = 0
+movedTextFilesCount = 0
 
 parser = argparse.ArgumentParser(
     prog="folderizer",
@@ -6,7 +17,92 @@ parser = argparse.ArgumentParser(
     epilog="Thanks for using %(prog)s!")
 parser.add_argument('filepath')
 parser.add_argument("-v","--version", action="version", version="%(prog)s 0.1.0")
+parser.add_argument("-d", "--default", action='store_true', help="Sorts files into folders by category (image, video, text, code, etc)")
 args = parser.parse_args()
-
+print(args, args.filepath, args.default)
+if args.default == True:
+    print("Default behaviour")
+    print(os.path.abspath(args.filepath))
+    target_path = os.path.abspath(args.filepath)
+    print("Target Path: " + target_path)
+    if (os.access(target_path, os.F_OK)):
+        print("Filepath exists")
+        print(os.scandir(target_path))
+        with os.scandir(target_path) as it:
+            for entry in it:
+                if not entry.name.startswith('.') and entry.is_file():
+                    print("Entry name: " + entry.name)
+                    print(os.path.splitext(entry.name)[1])
+                    if os.path.splitext(entry.name)[1] in images:
+                        imageCount+=1
+                        print("image detected")
+                        imagePath = target_path + '\images'
+                        print(imagePath)
+                        if not (os.access(imagePath, os.F_OK)):
+                            print('creating images folder')
+                            os.mkdir(imagePath)
+                        else:
+                            print("not creating images folder")
+                        # move file to images folder
+                        print("Image file name: " + entry.name)
+                        print(entry)
+                        oldPath = target_path + "\\" + entry.name
+                        newPath = imagePath + "\\" + entry.name
+                        print("old filepath: " + oldPath)
+                        print("new filepath: " + newPath)
+                        # attempt rename
+                        os.rename(oldPath, newPath)
+                        movedImagesCount+=1
+                    elif os.path.splitext(entry.name)[1] in videos:
+                        videoCount+=1
+                        print("video detected")
+                        videoPath = target_path + r'\videos'
+                        print(videoPath)
+                        if not (os.access(videoPath, os.F_OK)):
+                            print('creating videos folder!')
+                            os.mkdir(videoPath)
+                        else:
+                            print("not creating videos folder") 
+                        # move file to videos folder
+                        print("Video file name: " + entry.name)
+                        print(entry)
+                        oldPath = target_path + "\\" + entry.name
+                        newPath = videoPath + "\\" + entry.name
+                        print("old filepath: " + oldPath)
+                        print("new filepath: " + newPath)
+                        # attempt rename
+                        os.rename(oldPath, newPath)
+                        movedVideosCount+=1
+                    elif os.path.splitext(entry.name)[1] in text:
+                        textCount+=1
+                        print("text file detected")
+                        textPath = target_path + r'\textFiles'
+                        print(textPath)
+                        if not (os.access(textPath, os.F_OK)):
+                            print('creating textFiles folder!')
+                            os.mkdir(textPath)
+                        else:
+                            print("not creating textFiles folder")
+                        # move file to videos folder
+                        print("Text file name: " + entry.name)
+                        print(entry)
+                        oldPath = target_path + "\\" + entry.name
+                        newPath = textPath + "\\" + entry.name
+                        print("old filepath: " + oldPath)
+                        print("new filepath: " + newPath)
+                        # attempt rename
+                        os.rename(oldPath, newPath)
+                        movedTextFilesCount+=1
+            print('------------------------------------')
+            print('SUMMARY')
+            print('------------------------------------')
+            print('Images found: ',imageCount)
+            print('Images successfully moved: ', movedImagesCount)
+            print('Videos found: ',videoCount)
+            print('Videos successfully moved: ', movedVideosCount)
+            print('Text files found: ',textCount)
+            print('Text files successfully moved: ', movedTextFilesCount)
+    else:           
+        print("Filepath doesn't exist")
 def example_function():
     return 1 + 1

--- a/folderizer/__init__.py
+++ b/folderizer/__init__.py
@@ -20,7 +20,7 @@ parser.add_argument("-v","--version", action="version", version="%(prog)s 0.1.0"
 parser.add_argument("-d", "--default", action='store_true', help="Sorts files into folders by category (image, video, text, code, etc)")
 args = parser.parse_args()
 print(args, args.filepath, args.default)
-if args.default == True:
+if args.default:
     print("Default behaviour")
     print(os.path.abspath(args.filepath))
     target_path = os.path.abspath(args.filepath)


### PR DESCRIPTION
This fixes #3 

### Default Functionality

This adds support for a default behaviour:
```
folderizer [folder-name] --default
```

This moves the following **non-hidden files** into folders:
| File Category | Extensions | Folder Name
| --- | --- | --- |
| Images | `.jpeg`, `.jpg`, `.png`, `.gif` | images |
| Videos | `.mp4`, `.flv`, `.m4v`, `.webm` | videos |
| Text | `.txt`, `.md`, `.doc`, `.docx`, `.pdf` | textFiles |

This is a draft implementation, which will be refactored and iterated upon in the near future

### Future Considerations
- It might be good to add support for moving all code files into a folder called "code".
- It might also be good to add support for moving all other non-hidden files into a folder called "misc".
- It would be a good idea to revise some of the print() statements and incorporate them into a `--verbose` behaviour